### PR TITLE
Add support to visually represent hashes.

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -30,6 +30,7 @@ import { NETWORKS } from "./constants";
 import { Disclaimer } from "@/components/ui/disclaimer";
 import { calculateHashes } from "../components/safeHashesComponent";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import Blockies from "react-blockies";
 
 interface FormData {
   method: string; // "direct" or "api"
@@ -868,6 +869,11 @@ function HomeContent() {
                                   description: `${label} has been copied to your clipboard.`,
                                 });
                               }}
+                            />
+                            <Blockies
+                                seed={result.hashes?.[key as keyof typeof result.hashes]}
+                                size={20}
+                                scale={4}
                             />
                           </div>
                         </div>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -28,6 +28,7 @@
         "next": "^14.2.24",
         "next-themes": "^0.3.0",
         "react": "^18",
+        "react-blockies": "^1.4.1",
         "react-dom": "^18",
         "react-hook-form": "^7.53.1",
         "tailwind-merge": "^2.5.4",
@@ -4768,7 +4769,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -4819,6 +4819,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-blockies": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/react-blockies/-/react-blockies-1.4.1.tgz",
+      "integrity": "sha512-4N015X5oPNnD3xQPsiqolOFzPZSSWyc5mJhJUZShUCHtiGUxVN+1qsWTcglkHMNySux9hUofaispqcw9QkWP5Q==",
+      "dependencies": {
+        "prop-types": "^15.5.10"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -4849,8 +4860,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-remove-scroll": {
       "version": "2.6.3",

--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.8.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "react-blockies": "^1.4.1",
     "ethers": "^6.13.5",
     "lucide-react": "^0.453.0",
     "next": "^14.2.24",


### PR DESCRIPTION
This PR aims to visually represent the generated hashes.
This should dramatically help comparing hash strings.

Would be good if this could also be included on the Safe side and ideally on HW wallets.

I used react-blockies for this imlementation: https://github.com/stephensprinkle-zz/react-blockies#readme