### PR TITLE
Rename Optimism to OP Mainnet

### DIFF
--- a/app/app/constants.ts
+++ b/app/app/constants.ts
@@ -92,7 +92,7 @@ export const NETWORKS = [
     },
     {
       value: "optimism",
-      label: "Optimism",
+      label: "OP Mainnet",
       chainId: 10,
       gnosisPrefix: "oeth",
       logo: "networks/optimism.ico",


### PR DESCRIPTION
Updates the network name for Optimism to OP Mainnet